### PR TITLE
layout tweaks

### DIFF
--- a/Components/GameBoard/GameBoard.jsx
+++ b/Components/GameBoard/GameBoard.jsx
@@ -299,55 +299,15 @@ export class GameBoard extends React.Component {
         return player;
     }
 
-    renderStatusArea(thisPlayer, otherPlayer) {
-        let boundActionCreators = bindActionCreators(actions, this.props.dispatch);
-        return [
-            <div className='prompt-area'>
-                <div className='player-stats-row other-side'>
-                    <PlayerStats stats={ otherPlayer.stats }
-                        user={ otherPlayer.user } firstPlayer={ otherPlayer.firstPlayer } />
-                </div>
-                <div className='shootout-status'>
-                    <div className='panel' style={ {
-                        height: '200px'
-                    } }>
-                        <div>Shootout/Lowball panel <br/> Not yet implemented</div>
-                    </div>
-                    <div className='panel' style={ {
-                        height: '200px'
-                    } }>
-                        <div>Shootout/Lowball panel <br/> Not yet implemented</div>
-                    </div>
-                </div>
-                <div className='inset-pane'>
-                    <ActivePlayerPrompt
-                        cards={ this.props.cards }
-                        buttons={ thisPlayer.buttons }
-                        controls={ thisPlayer.controls }
-                        promptText={ thisPlayer.menuTitle }
-                        promptTitle={ thisPlayer.promptTitle }
-                        onButtonClick={ this.onCommand }
-                        onMouseOver={ this.onMouseOver }
-                        onMouseOut={ this.onMouseOut }
-                        user={ this.props.user }
-                        phase={ thisPlayer.phase }
-                        timerLimit={ this.props.timerLimit }
-                        timerStartTime={ this.props.timerStartTime }
-                        stopAbilityTimer={ this.props.stopAbilityTimer } />
-                </div>
-                <div className='player-stats-row'>
-                    <PlayerStats { ...boundActionCreators } stats={ thisPlayer.stats } showControls={ !this.state.spectating } user={ thisPlayer.user }
-                        firstPlayer={ thisPlayer.firstPlayer } onSettingsClick={ this.onSettingsClick } showMessages
-                        onMessagesClick={ this.onMessagesClick } numMessages={ this.state.newMessages } />
-                </div>
-            </div>
-        ];
-    }
-
     renderBoard(thisPlayer, otherPlayer) {
+        let boundActionCreators = bindActionCreators(actions, this.props.dispatch);
         return [
             <div key='board-middle' className='board-middle'>
                 <div className='player-home-row'>
+                    <div className='player-stats-row other-side'>
+                        <PlayerStats stats={ otherPlayer.stats }
+                            user={ otherPlayer.user } firstPlayer={ otherPlayer.firstPlayer } />
+                    </div>
                     <PlayerRow
                         hand={ otherPlayer.cardPiles.hand } isMe={ false }
                         drawHand={ otherPlayer.cardPiles.drawHand } isMe={ false }						
@@ -367,9 +327,37 @@ export class GameBoard extends React.Component {
                         side='top'
                         cardSize={ this.props.user.settings.cardSize } />
                 </div>
-                { this.renderStatusArea(thisPlayer, otherPlayer) }
+                <div className='prompt-area'>
+                    <div className='shootout-status'>
+                        <div className='panel' style={ {
+                            height: '200px'
+                        } }>
+                            <div>Shootout/Lowball panel <br/> Not yet implemented</div>
+                        </div>
+                        <div className='panel' style={ {
+                            height: '200px'
+                        } }>
+                            <div>Shootout/Lowball panel <br/> Not yet implemented</div>
+                        </div>
+                    </div>
+                </div>
+                <div className='inset-pane'>
+                    <ActivePlayerPrompt
+                        cards={ this.props.cards }
+                        buttons={ thisPlayer.buttons }
+                        controls={ thisPlayer.controls }
+                        promptText={ thisPlayer.menuTitle }
+                        promptTitle={ thisPlayer.promptTitle }
+                        onButtonClick={ this.onCommand }
+                        onMouseOver={ this.onMouseOver }
+                        onMouseOut={ this.onMouseOut }
+                        user={ this.props.user }
+                        phase={ thisPlayer.phase }
+                        timerLimit={ this.props.timerLimit }
+                        timerStartTime={ this.props.timerStartTime }
+                        stopAbilityTimer={ this.props.stopAbilityTimer } />
+                </div>
                 <div className='play-area' onDragOver={ this.onDragOver }>
-					
                     <div className='player-street other-side'>
                         <PlayerStreet onMouseOver={ this.onMouseOver } onMouseOut={ this.onMouseOut } onClick={ this.onCardClick } onDragDrop={ this.onDragDrop }
                             onMenuItemClick={ this.onMenuItemClick } className='other-side' owner={ otherPlayer } otherPlayer={ otherPlayer } 
@@ -407,6 +395,11 @@ export class GameBoard extends React.Component {
                     </div>
                 </div>
                 <div className='player-home-row our-side'>
+                    <div className='player-stats-row'>
+                        <PlayerStats { ...boundActionCreators } stats={ thisPlayer.stats } showControls={ !this.state.spectating } user={ thisPlayer.user }
+                            firstPlayer={ thisPlayer.firstPlayer } onSettingsClick={ this.onSettingsClick } showMessages
+                            onMessagesClick={ this.onMessagesClick } numMessages={ this.state.newMessages } />
+                    </div>
                     <PlayerRow isMe={ !this.state.spectating }
                         hand={ thisPlayer.cardPiles.hand }
                         drawHand={ thisPlayer.cardPiles.drawHand }						

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -421,7 +421,8 @@ span.down-arrow {
 .play-area {
   overflow-x: auto;
   grid-column: 2;
-  grid-row: 2;
+  grid-row-start: 2;
+  grid-row-end: 4;
 }
 
 .play-area, .player-board {
@@ -468,12 +469,12 @@ span.down-arrow {
   overflow-x: auto;
   overflow-y: hidden;
   grid-row: 1;
-  grid-column-start: 2;
+  grid-column-start: 1;
   grid-column-end: 4;
   justify-self: stretch;
 
   &.our-side {
-    grid-row: 3;
+    grid-row: 4;
   }
 }
 
@@ -559,8 +560,8 @@ span.down-arrow {
 
 .board-middle {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  grid-template-rows: auto 1fr auto;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr auto auto;
   flex-grow: 1;
 }
 

--- a/less/status.less
+++ b/less/status.less
@@ -4,6 +4,8 @@
   width: 210px;
   max-height: 300px;
   justify-content: space-between;
+  grid-column: 1;
+  grid-row: 3;
   z-index: @layer-top;
 }
   
@@ -17,8 +19,8 @@
   display: grid;
   grid-template-rows: auto 1fr auto auto;
   grid-column: 1;
-  grid-row-start: 1;
-  grid-row-end: 4;
+  grid-row: 2;
+  overflow-x: auto;
   
   .panel {
     padding-left: 5px;
@@ -32,22 +34,11 @@
   justify-content: space-between;
 }
 
-.player-stats-row.other-side {
-  flex: 1;
-}
-
 .player-stats {
   display: grid;
   grid-template-columns: 110px 55px 55px;
   grid-template-rows: 1fr 1fr 1fr;  
   align-items: center;
-
-  &.panel {
-    margin: 0;
-    border-radius: 0;
-    padding: 5px;
-    position: initial;
-  }
 }
 
 .shootout-status {


### PR DESCRIPTION
this puts the player status panels inside the player rows, and places the shootout and status panels stacked on top of each other to the left of the board-middle and vertically sandwiched between the top and bottom player rows.

this seems to all fit into the targeted 1366x768 screen size, but only barely. 

![image](https://user-images.githubusercontent.com/1410427/118382566-c5f2f080-b5ab-11eb-8efe-0d2928f98a7d.png)

overall, i'm not a huge fan, but at least the current player's status panel doesn't get pushed out of view-port anymore.